### PR TITLE
Add devcontainer for GitHub Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,38 @@
+# GRASS 8.5 matches software.grass.version in _variables.yml. The osgeo image
+# ships GRASS built against GDAL and PDAL, which is what Topics 3-5 need
+# (r.in.pdal, v.in.pdal, the pdal CLI).
+FROM osgeo/grass-gis:8.5.0-ubuntu
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Devcontainer basics, the toolchain g.extension needs to build addons, and the
+# runtime libraries OpenCV pulls in through ultralytics and segment-geospatial.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        git \
+        less \
+        libgl1 \
+        libglib2.0-0t64 \
+        nano \
+        openssh-client \
+        procps \
+        python3-dev \
+        unzip \
+        vim \
+        wget \
+        zip \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv manages the course virtual environment, same as CONTRIBUTING.md describes
+# for a local checkout.
+COPY --from=ghcr.io/astral-sh/uv:0.9.6 /uv /uvx /usr/local/bin/
+
+# Makes `import grass.script` work from any interpreter, including the .venv,
+# without the `grass --config python_path` dance the notebooks use on Colab.
+ENV PYTHONPATH=/usr/local/grass85/etc/python \
+    UV_LINK_MODE=copy
+
+WORKDIR /workspaces/gis-584-uas-course
+
+CMD ["/bin/bash"]

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,90 @@
+# Devcontainer
+
+A ready-to-use environment for the course assignments and for editing the site.
+It runs in [GitHub Codespaces](https://github.com/features/codespaces) or locally
+in VS Code with the Dev Containers extension.
+
+## Start a Codespace
+
+From the repository page: **Code > Codespaces > Create codespace on main**.
+The first build takes roughly 10 minutes; after that the Codespace starts in
+seconds. Locally: **Dev Containers: Reopen in Container** from the VS Code
+command palette.
+
+## What is in it
+
+| Component | Version | Notes |
+|---|---|---|
+| GRASS | 8.5.0 | `osgeo/grass-gis:8.5.0-ubuntu`, built with GDAL and PDAL |
+| GDAL | 3.12.3 | CLI and Python bindings |
+| PDAL | CLI | used by `pdal info` in the point cloud lab |
+| Python | 3.12 | Ubuntu 24.04 system interpreter |
+| Quarto | 1.9.38 | matches the version in README.md |
+| uv | 0.9.6 | creates and manages `.venv` |
+
+`requirements.txt` is installed into `.venv` at container creation, together
+with a CPU-only build of PyTorch (the default wheels pull in several GB of CUDA
+libraries that a Codespace cannot use).
+
+These GRASS addons are installed as well, because the assignments call them:
+`i.segment.stats`, `i.superpixels.slic`, `r.confusionmatrix`, `r.learn.ml2`,
+`r.local.relief`, `r.patch.smooth`, `r.sample.category`, `r.shaded.pca`,
+`r.skyview`, `v.profile.points`. Anything else the assignments use is core
+GRASS 8.5. Install more with `g.extension extension=<name>`.
+
+`PYTHONPATH` points at the GRASS Python packages, so `import grass.script` and
+`import grass.jupyter` work in any notebook or terminal without the
+`grass --config python_path` step the Colab notebooks need.
+
+## Course data
+
+The GRASS project used from Topic 3 onward is not in the repository. Download it
+into `~/grassdata` with:
+
+```bash
+bash .devcontainer/get-course-data.sh
+```
+
+Then start GRASS:
+
+```bash
+grass ~/grassdata/Lake_Wheeler_NCspm/PERMANENT
+```
+
+Individual rasters, orthophotos and point clouds are pulled straight from their
+URLs in `_variables.yml` by the assignments, mostly through `r.import` and
+`r.in.pdal`.
+
+## Working on the site
+
+```bash
+quarto preview --port 4200
+```
+
+Port 4200 is forwarded and opens in the VS Code preview pane. `quarto preview`
+otherwise picks a random port, which the forwarding rules do not cover, so pass
+`--port` explicitly. A full render goes to `docs/`:
+
+```bash
+quarto render
+```
+
+## Notebooks
+
+Jupyter is in `.venv` and the Python and Jupyter extensions are preinstalled, so
+notebooks run directly in the editor. Port 8888 is forwarded for a standalone
+server:
+
+```bash
+jupyter lab --ip 0.0.0.0 --no-browser
+```
+
+## Not covered
+
+- **Topic 7 (WebODM)** needs Docker and enough RAM and disk for photogrammetry.
+  Keep running it locally per `assignment_7a.qmd`.
+- **Agisoft Metashape** (Topic 2) is licensed desktop software and is not in the
+  container.
+- **The wxGUI** is not usable here; this image has no display server. Work from
+  the command line, from notebooks with `grass.jupyter`, or run the GUI in a
+  local GRASS install.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,57 @@
+{
+  "name": "GIS/MAE 584 UAS Mapping and Analytics",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
+  "workspaceFolder": "/workspaces/gis-584-uas-course",
+  "hostRequirements": {
+    "cpus": 2,
+    "memory": "8gb",
+    "storage": "32gb"
+  },
+  "features": {
+    "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
+      "version": "1.9.38"
+    }
+  },
+  "remoteEnv": {
+    "PATH": "${containerWorkspaceFolder}/.venv/bin:${containerEnv:PATH}"
+  },
+  "forwardPorts": [4200, 8888],
+  "portsAttributes": {
+    "4200": {
+      "label": "Quarto preview",
+      "onAutoForward": "openPreview"
+    },
+    "8888": {
+      "label": "Jupyter",
+      "onAutoForward": "silent"
+    }
+  },
+  "postCreateCommand": "bash .devcontainer/postCreate.sh",
+  "waitFor": "postCreateCommand",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-toolsai.jupyter",
+        "quarto.quarto",
+        "redhat.vscode-yaml"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "python.defaultInterpreterPath": "${containerWorkspaceFolder}/.venv/bin/python",
+        "python.terminal.activateEnvironment": false,
+        "jupyter.notebookFileRoot": "${workspaceFolder}",
+        "files.watcherExclude": {
+          "**/.venv/**": true,
+          "**/_freeze/**": true,
+          "**/docs/**": true
+        }
+      }
+    }
+  },
+  "remoteUser": "root"
+}

--- a/.devcontainer/get-course-data.sh
+++ b/.devcontainer/get-course-data.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Downloads the Lake Wheeler GRASS project (~216 MB) into ~/grassdata. Assignments
+# in Topics 3, 4 and 5 start from this project. Run it on demand; it is not part
+# of container creation.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GRASSDATA="$HOME/grassdata"
+
+# Single source of truth for dataset URLs is _variables.yml.
+URL="$(awk '/^[[:space:]]*lake_wheeler_url:/ {print $2; exit}' "$REPO_ROOT/_variables.yml")"
+if [ -z "$URL" ]; then
+    echo "Could not read data.lake_wheeler_url from _variables.yml" >&2
+    exit 1
+fi
+
+if [ -d "$GRASSDATA/Lake_Wheeler_NCspm" ]; then
+    echo "$GRASSDATA/Lake_Wheeler_NCspm already exists, nothing to do."
+    exit 0
+fi
+
+mkdir -p "$GRASSDATA"
+echo "==> Downloading $URL"
+curl -fL --progress-bar -o "$GRASSDATA/Lake_Wheeler_NCspm.zip" "$URL"
+
+echo "==> Unpacking into $GRASSDATA"
+unzip -q "$GRASSDATA/Lake_Wheeler_NCspm.zip" -d "$GRASSDATA"
+rm "$GRASSDATA/Lake_Wheeler_NCspm.zip"
+
+echo
+echo "Start GRASS with:"
+echo "  grass $GRASSDATA/Lake_Wheeler_NCspm/PERMANENT"

--- a/.devcontainer/install-grass-addons.sh
+++ b/.devcontainer/install-grass-addons.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# GRASS addons the course assignments call. Everything else the assignments use
+# is core GRASS 8.5. Failures are reported but do not stop container creation;
+# any addon can be installed later with `g.extension extension=<name>`.
+#
+# g.extension warns that it cannot copy grassdocs.css and friends: the base image
+# ships without the HTML manual, so addon manual pages are unstyled. Harmless.
+set -uo pipefail
+
+ADDONS=(
+    i.segment.stats
+    i.superpixels.slic
+    r.confusionmatrix
+    r.learn.ml2
+    r.local.relief
+    r.patch.smooth
+    r.sample.category
+    r.shaded.pca
+    r.skyview
+    v.profile.points
+)
+
+# g.extension needs a session, so run the whole list inside one temporary project.
+grass --tmp-project XY --exec bash -c '
+failed=""
+for addon in "$@"; do
+    echo "--> g.extension $addon"
+    g.extension extension="$addon" || failed="$failed $addon"
+done
+if [ -n "$failed" ]; then
+    echo "Addons that did not install:$failed"
+    exit 1
+fi
+' _ "${ADDONS[@]}"

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Builds the course Python environment inside the devcontainer. Runs once, when
+# the container is created (or rebuilt).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+VENV="$REPO_ROOT/.venv"
+PY="$VENV/bin/python"
+
+echo "==> Creating .venv (system site packages expose the image's GDAL bindings and numpy)"
+uv venv --python /usr/bin/python3 --system-site-packages "$VENV"
+
+# ultralytics and segment-geospatial both depend on torch. The default PyPI
+# wheels drag in several GB of CUDA libraries that a Codespace cannot use, so
+# pin the CPU build first and let the rest of the requirements resolve against it.
+echo "==> Installing CPU-only PyTorch"
+uv pip install --python "$PY" --index-url https://download.pytorch.org/whl/cpu torch torchvision
+
+echo "==> Installing course requirements"
+uv pip install --python "$PY" -r requirements.txt
+
+echo "==> Installing GRASS addons used by the course"
+bash "$REPO_ROOT/.devcontainer/install-grass-addons.sh" || \
+    echo "WARNING: addon install reported problems, see the log above"
+
+mkdir -p "$HOME/grassdata"
+
+echo
+echo "==> Environment"
+# sed instead of head: head closes the pipe early, which trips SIGPIPE under
+# `set -o pipefail`.
+grass --version | sed -n '1p'
+gdalinfo --version
+pdal --version | sed -n '/pdal/p'
+echo "Quarto $(quarto --version)"
+"$PY" --version
+echo
+echo "GRASS database directory: $HOME/grassdata (empty)"
+echo "Course data: bash .devcontainer/get-course-data.sh"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ mogrify -format webp -quality 80 *.{png,PNG,jpg,JPG}
 - `execute: freeze: auto` in `_quarto.yml`: local renders reuse cached results in `_freeze/`. The production profile (`_quarto-production.yml`, activated with `QUARTO_PROFILE=production`) sets `freeze: false`, so CI re-executes all code cells.
 - `docs/` and `_freeze/` are gitignored build artifacts; never commit or hand-edit them.
 - CI: `.github/workflows/pr-check.yml` renders the site on PRs to `main`; `publish.yml` renders with the production profile and pushes `docs/` to the `gh-pages` branch on push to `main` (Pages deploys from that branch).
+- Codespaces: `.devcontainer/` builds on `osgeo/grass-gis:8.5.0-ubuntu` and installs `requirements.txt` into `.venv` (CPU-only torch) plus the course GRASS addons at container creation. Keep the image tag in `.devcontainer/Dockerfile` in sync with `software.grass.version` in `_variables.yml`, and the Quarto feature version in sync with README.md. `.devcontainer/get-course-data.sh` pulls the Lake Wheeler project into `~/grassdata`.
 - Notebook-shaped assignments (currently 3A, 6A, 6B) publish a runnable `.ipynb` to the site: qmd-based ones add `ipynb: default` as a second format, ipynb-based ones list the notebook under `resources:`. Their "Open in Colab" badges point at `colab.research.google.com/github/ncsu-geoforall-lab/gis-584-uas-course/blob/gh-pages/<path>.ipynb`, so Colab always opens the render-generated copy.
 
 ## Content architecture

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # GIS/MAE 584 Mapping and Analytics Using UAS
 
 [![Quarto Publish](https://github.com/ncsu-geoforall-lab/gis-584-uas-course/actions/workflows/publish.yml/badge.svg?branch=main)](https://github.com/ncsu-geoforall-lab/gis-584-uas-course/actions/workflows/publish.yml)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/ncsu-geoforall-lab/gis-584-uas-course)
 
 Course website for GIS/MAE 584 Mapping and Analytics Using UAS
 
@@ -11,6 +12,26 @@ Course website for GIS/MAE 584 Mapping and Analytics Using UAS
 ## Configuration
 
 Install Quarto following the directions at [https://quarto.org/docs/get-started/](https://quarto.org/docs/get-started/)
+
+## GitHub Codespaces
+
+A Codespace gives you the course stack in the browser with nothing to install
+locally: GRASS 8.5 built with GDAL and PDAL, Python 3.12 with the packages in
+`requirements.txt`, Jupyter, Quarto, and the GRASS addons the assignments use.
+
+Start one from **Code > Codespaces > Create codespace on main**, or with the
+badge above. The first build takes about 10 minutes.
+
+The Lake Wheeler GRASS project is not in the repository. Download it inside the
+Codespace with:
+
+```bash
+bash .devcontainer/get-course-data.sh
+grass ~/grassdata/Lake_Wheeler_NCspm/PERMANENT
+```
+
+See [.devcontainer/README.md](.devcontainer/README.md) for what the environment
+contains and what it does not cover (WebODM, Agisoft Metashape, the wxGUI).
 
 ## Development
 


### PR DESCRIPTION
Gives students a working course environment in the browser, so Topics 3 to 6 do not depend on a local GRASS, GDAL and PDAL install.

## What it provides

| Component | Version |
|---|---|
| GRASS | 8.5.0 (`osgeo/grass-gis:8.5.0-ubuntu`, built with GDAL and PDAL) |
| GDAL | 3.12.3, CLI and Python bindings |
| PDAL | 2.10.1 CLI, used by `pdal info` in the point cloud lab |
| Python | 3.12 with `requirements.txt` in `.venv` |
| Quarto | 1.9.38, matching README.md |
| uv | 0.9.6 |

- `PYTHONPATH` points at the GRASS Python packages, so `import grass.script` and `import grass.jupyter` work in any notebook or terminal without the `grass --config python_path` step the Colab notebooks need.
- torch is installed from the PyTorch CPU index before the rest of the requirements. `ultralytics` and `segment-geospatial` otherwise pull in several GB of CUDA libraries a Codespace cannot use.
- `postCreate.sh` installs the ten addons the assignments call: `i.segment.stats`, `i.superpixels.slic`, `r.confusionmatrix`, `r.learn.ml2`, `r.local.relief`, `r.patch.smooth`, `r.sample.category`, `r.shaded.pca`, `r.skyview`, `v.profile.points`. Everything else the assignments use is core GRASS 8.5.
- `get-course-data.sh` downloads the Lake Wheeler project (216 MB) into `~/grassdata`, reading the URL from `_variables.yml`. It is opt-in, not part of container creation.
- Extensions: Python, Pylance, Jupyter, Quarto, YAML. Ports 4200 (Quarto preview) and 8888 (Jupyter) forwarded.
- README gets a Codespaces badge and a short section; `.devcontainer/README.md` has the detail.

## Not covered

- Topic 7 (WebODM) needs Docker and real photogrammetry compute, so it stays local per `assignment_7a.qmd`.
- Agisoft Metashape is licensed desktop software.
- The wxGUI has no display server here. Command line and `grass.jupyter` work.

## Verified

Built locally with the devcontainer CLI against Docker 29.7, on a copy of the repo:

- Image builds, Quarto feature installs 1.9.38, `postCreate.sh` exits 0.
- All ten addons install, including the C addon `i.superpixels.slic`.
- torch 2.13.0+cpu and torchvision 0.28.0+cpu resolve, no CUDA packages. `.venv` is 2.0 GB.
- `import grass.script` and `import grass.jupyter` from `.venv`, plus `g.region`, `r.mapcalc` and `r.slope.aspect` in a temporary project.
- `pdal info` and `r.in.pdal` and `v.in.pdal` on the course lidar file `mid_pines_spm_2013.laz`, 5,882,031 points imported to raster and vector.
- `quarto render index.qmd` and `quarto render` of the jupyter-engine assignment 6B, which produces the `.ipynb` the Colab badge points at.
- `get-course-data.sh` downloads and unpacks Lake Wheeler, and `g.list` reads the DSMs.

Not verified: an actual Codespace on GitHub infrastructure, or a full `quarto render` of the site.

## Note for course content

GRASS 8.5 dropped the libLAS based `r.in.lidar`, `v.in.lidar` and `r3.in.lidar`, which several assignments still use. They are not in the container and there is no addon replacement. The PDAL equivalents `r.in.pdal` and `v.in.pdal` are available. Worth a separate pass over the assignment text.